### PR TITLE
Convert RST to Markdown with pandoc

### DIFF
--- a/docs/administrative/access_account.md
+++ b/docs/administrative/access_account.md
@@ -1,0 +1,42 @@
+---
+title: Get access to Account Switcher
+---
+
+The Account Switcher feature is available for only Fanatical Amazon Web
+Services (FAWS) customers who use [Rackspace Technology Identity
+Federation](https://docs.rackspace.com/docs/rackspace-federation/) to
+access their accounts.
+
+Complete the following steps to gain access to the Account Switcher
+feature:
+
+1.  Contact your Customer Support Manager (CSM).
+
+    Your CSM helps you determine if your account setup is a candidate
+    for the Account Switcher beta.
+
+2.  Complete the legal agreement document and attach it to a support
+    ticket. This document requires information about the accounts you
+    plan to link. You receive a notification after the account linking
+    completes.
+
+3.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com). Use the Account Switcher
+    drop-down menu option to switch to delegate accounts.
+
+    You can see ticketing information for only the account that you are
+    currently accessing. Use the Account Switcher drop-down menu option
+    to change to the account for which you want to view tickets.
+
+    You always see notifications for your primary account. You do not
+    see notifications for other principal or trusted accounts.
+
+::: note
+::: title
+Note
+:::
+
+Support cannot verify you over the phone for linked accounts.
+:::
+
+![\*\*account switcher\*\*](/_images/acc_switcher.png)

--- a/docs/administrative/access_permissions.md
+++ b/docs/administrative/access_permissions.md
@@ -1,0 +1,49 @@
+---
+title: Group permissions for linked accounts
+---
+
+After you establish Domain trust between the principal account and
+delegate accounts, principal account administrators can create groups
+and assign permissions.
+
+Principal account administrative users can view group permissions for
+their account.
+
+# Manage group permissions in the principal account
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+
+2.  Select **Account \> User Management** from the global navigation
+    menu.
+
+3.  Select the **User groups** tab.
+
+4.  Use the **Group permissions** drop-down menu to navigate to linked
+    accounts.
+
+    ![\*\*account switcher\*\*](/_images/acct_groups.png)
+
+5.  Select a trusting account and follow the steps to
+    `manage your user groups<user_settings>`{.interpreted-text
+    role="ref"}.
+
+Federated Identity groups have additional product permissions. Select
+the **Federated Identity Users** tab and choose from the available
+options.
+
+1.  Toggle the switch to allow group members to create new AWS accounts.
+
+    > ::: note
+    > ::: title
+    > Note
+    > :::
+    > :::
+    >
+    > This option is available for only the principal account.
+
+2.  Select a default AWS IAM policy from the drop-down list.
+
+3.  Edit additional product permissions.
+
+![\*\*account switcher\*\*](/_images/acct_products.png)

--- a/docs/administrative/access_permissions_users.md
+++ b/docs/administrative/access_permissions_users.md
@@ -1,0 +1,38 @@
+---
+title: User permissions for linked accounts
+---
+
+After you establish Domain trust between the principal account and
+delegate accounts, principal account administrators can manage
+permissions for users in their account.
+
+# View users in the principal account
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+2.  Select **Account \> User Management** from the global navigation
+    menu.
+3.  Select the **Users** tab.
+4.  Select a user.
+
+![\*\*account switcher\*\*](/_images/acct_users.png)
+
+# Manage users
+
+Selecting a user displays standard information outlined in the
+`manage your users<user_settings>`{.interpreted-text role="ref"}
+section, as well as options specific to the Account Switcher feature.
+
+-   Use the drop-down menu to switch between linked accounts.
+
+-   Toggle to give a user permission to create new AWS accounts.
+
+    > ::: note
+    > ::: title
+    > Note
+    > :::
+    >
+    > This option is available for only the principal account.
+    > :::
+
+![\*\*account switcher\*\*](/_images/acct_single_users.png)

--- a/docs/administrative/account_revoke.md
+++ b/docs/administrative/account_revoke.md
@@ -1,0 +1,6 @@
+---
+title: Remove Account Switching
+---
+
+Contact support to revoke domain trust between a principal account and a
+delegate account. This action removes the Account Switching feature.

--- a/docs/administrative/acct_switcher.md
+++ b/docs/administrative/acct_switcher.md
@@ -1,0 +1,43 @@
+---
+title: Account Switcher
+---
+
+::: note
+::: title
+Note
+:::
+
+This feature is currently in beta and is only available for Fanatical
+Amazon Web Services (FAWS) customers who use [Rackspace Technology
+Identity
+Federation](https://docs.rackspace.com/docs/rackspace-federation/) to
+access their accounts.
+:::
+
+The Account Switcher feature simplifies the account management process
+by making it easy to quickly switch which Rackspace account the user is
+currently working within. Account Switcher helps large enterprise
+customers with sprawling relationships and Federated Identity management
+to streamline their workflow.
+
+# Account linking
+
+Account linking can occur after multiple accounts are linked together
+through an agreement. In this model, you can grant users from a delegate
+Rackspace account access to resources in a principal Rackspace account.
+Members of the principal account can log into the [Rackspace Technology
+Customer Portal](https://login.rackspace.com) and use the **Account
+Linking** drop-down menu to navigate to connected delegate accounts.
+
+Contact your Customer Support Manager to request access to Account
+Switcher.
+
+# Additional information
+
+The following sections provide additional information about the Account
+Switcher feature.
+
+::: {.toctree maxdepth="1"}
+access_account.rst access_permissions_users.rst access_permissions
+account_revoke.rst
+:::

--- a/docs/administrative/change_account_company_name.md
+++ b/docs/administrative/change_account_company_name.md
@@ -1,0 +1,68 @@
+---
+title: Change your Account Company Name
+---
+
+Complete a **Service Transfer** form if your company has filed for a
+name change with the Secretary of State where the company is registered,
+and the tax ID is changed.
+
+You can download the **Service Transfer** form by using the following
+steps:
+
+**Note** If you are a Private Cloud customer, you can request all of the
+forms described in this guide from your Account Manager.
+
+**Step 1.** Log in to the [Rackspace Technology Customer
+Portal](https://login.rackspace.com/).
+
+**Step 2.** In the top navigation panel, select **Account \>\> Docs and
+Forms**.
+
+![docs & forms](docs&forms.png){width="349px"}
+
+**Step 3.** In the **Documents and Forms** page, select the appropriate
+options below **Transfer Ownership to a new Account owner**:
+
+> -   Fanatical Support for AWS customer, download the **Fanatical
+>     Support for AWS Service Transfer Form**.
+> -   Other customers, download the **Service Transfer Form**.
+
+**Step 4.** Complete the downloaded form and save the edited file on
+your computer.
+
+**Step 5.** Return to the [Rackspace Technology Customer
+Portal](https://login.rackspace.com/).
+
+**Step 6.** Select **Tickets** \> **Create Ticket** from the top
+navigation panel.
+
+![create ticket](createticket.png){width="331px"}
+
+**Step 6.** In **Create Ticket** page, select the appropriate
+**Category** from Category section and click **Continue**.
+
+![category](category.png){width="470px"}
+
+**Step 7.** In **Account & Product** section, click **drop-down** and
+select the appropriate **Account**, **Product**, and **Severity** and
+click **Continue** as shown in the below image.
+
+![account product & severity](accountproduct&severity.png){width="380px"}
+
+**Step 8.** In **Issue Details** section, fill in details of Subject,
+Description, and Recipient(s). Upload the **Account Change Form** as
+attachments with **Company Name Change Request** in the subject line and
+click **Submit**. Your ticket will be created.
+
+![issue details](issuedetails.png){width="379px"}
+
+# Name change without a new tax ID or ownership
+
+If the company name has changed but the tax ID or ownership did not
+change, you must complete one of the following forms to provide evidence
+of the name change.
+
+These forms are available from the **Secretary of State**.
+
+-   Certificate of Name Change
+-   Certificate of Amendment

--- a/docs/administrative/change_cloud_account_owner.md
+++ b/docs/administrative/change_cloud_account_owner.md
@@ -1,0 +1,49 @@
+---
+title: Change your Cloud Account Owner
+---
+
+When a Primary User/Account Owner leaves the company or the name of the
+company or project changes, then you need to change the Primary
+User/Account Owner. To Update this information for your Rackspace
+Technology Cloud and Amazon Web Services® (AWS) accounts, Login to
+[Rackspace Technology Customer Portal](https://login.rackspace.com).
+
+**Note: Only the current Account Owner can assign a New Account Owner.**
+
+**When you Change the Account Owner**:
+
+-   You must select the new or promoted user from existing users on the
+    account.
+-   The selected user becomes the Primary Contact and has full control
+    over the account.
+-   As the former or demoted primary user, you are set up as an
+    Administrative contact type and given basic [Role-Based Access
+    Control (RBAC) Identity
+    permissions](https://developer.rackspace.com/docs/cloud-identity/v2/getting-started/).
+    The primary user might need to set up RBAC permissions for the
+    demoted user.
+
+You can **Change the Account Owner** by using the following steps:
+
+**Step 1** Log in to the [Rackspace Technology Customer
+Portal](https://login.rackspace.com).
+
+**Step 2** In the global navigation menu, click **Account** \>\>
+**Account Settings**.
+
+![account setting](accountsetting.png){width="590px"}
+
+**Step 3** In Account Settings page, click **Update** next to **Account
+Owner**.
+
+![update owner](updateowner.png){width="656px"}
+
+**Step 4** In Update Account Owner page, select a **User** from the User
+list to be assigned as New Account Owner. Fill in the address details of
+Account Owner and click **Submit**.
+
+![select owner new](selectownernew.png){width="553px"}
+
+**Step 5** Click **Confirm** to change the **Primary Account Owner**.
+
+![confirm new owner](confirmnewowner.png){width="793px"}

--- a/docs/administrative/index.md
+++ b/docs/administrative/index.md
@@ -1,0 +1,13 @@
+---
+title: Make administrative changes to your account
+---
+
+If you have the appropriate account permissions, you can use the global
+navigation menu to manage account users and groups. The following
+sections include important information about managing Rackspace
+Technology users and groups.
+
+::: {.toctree maxdepth="1"}
+update_primary_contact.rst change_account_company_name.rst
+change_cloud_account_owner.rst acct_switcher.rst
+:::

--- a/docs/administrative/update_primary_contact.md
+++ b/docs/administrative/update_primary_contact.md
@@ -1,0 +1,22 @@
+---
+title: Update your Account\'s Primary Contact
+---
+
+**Note: The primary contact for your account must be an active user**
+
+You can download the **Primary Contact Change** form by using the
+following steps:
+
+**Step 1.** Log in to the Rackspace Technology Portal
+\<<https://login.rackspace.com/>\>.
+
+**Step 2.** In the top navigation panel, select **Account \>\> Docs and
+Forms**.
+
+![acc docs & forms](accdocs&forms.png){width="718px"}
+
+**Step 3.** Under **Compliance Documents and Forms** click **Primary
+Contact Change Form**. Complete the **Primary Contact Change Form** and
+attach it on your support ticket.
+
+![change primary contact form](changeprimarycontactform.png){width="647px"}

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,25 @@
+---
+title: Account dashboard
+---
+
+The account dashboard displays all your Rackspace Technology accounts in
+a single view.
+
+To view the account dashboard:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+
+2.  Click the **Select a Product** drop-down option in the upper-left
+    corner.
+
+    > ![\*\*dropdown menu to view account dashboard\*\*](/_static/img/my_account.png)
+
+3.  Select **My Accounts**. The account dashboard displays.
+
+    Use the search bar or select the funnel icon to search or filter
+    available accounts.
+
+    Select an account to display additional details, if available.
+
+    > ![\*\*the solutions dashboard\*\*](/_static/img/solutions_dashboard.png)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,18 @@
+---
+title: Rackspace Technology Customer Portal Onboarding Guide
+---
+
+This user guide provides an introduction to the Rackspace Technology
+Customer Portal. The following sections include details about common
+tasks that you can perform using this portal.
+
+The following sections provide information about the Customer Portal:
+
+::: {.toctree maxdepth="2"}
+Rackspace Technology Customer Portal Onboarding Guide \<self\>
+intended_audience.rst introduction.rst dashboard.rst
+portal_profile/index.rst manage_portal_user_groups/index.rst
+administrative/index.rst understand_billing/index.rst
+manage_billing/index.rst tickets/index.rst notifications/index.rst
+support.rst
+:::

--- a/docs/intended_audience.md
+++ b/docs/intended_audience.md
@@ -1,0 +1,12 @@
+---
+title: Intended audience
+---
+
+This guide is intended for new Rackspace Technology customers who use
+[the Rackspace Technology Customer
+Portal](https://login.rackspace.com/login) to manage their account. Some
+solutions, like ObjectRocket and Onica, have their own portals and do
+not require access to [The Rackspace Technology Customer
+Portal](https://login.rackspace.com/login). For more information about
+these solutions, refer to the relevant documentation on the [Rackspace
+Technology Support site](https://developer.rackspace.com/).

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,43 @@
+---
+title: Log in to the Rackspace Technology customer portal
+---
+
+When you become a Rackspace Technology customer, we provide you with
+access to customer portals for managing your cloud accounts. These
+portals are different for [Public
+Cloud](https://www.rackspace.com/cloud/public) and [Private
+Cloud](https://www.rackspace.com/cloud/private) customers.
+
+# The account registration code
+
+Rackspace Technology uses an account registration code to verify new
+users. When an account administrator adds you as a user, you receive an
+email with your account registration code and instructions on how to log
+in to the [Rackspace Technology Customer
+Portal](https://login.rackspace.com) for the first time. You need this
+registration code only during your first login or if you forget your
+user name.
+
+The primary contact on the account is the only person who can change
+this code. When the primary contact adds a user, the user receives a
+registration code.
+
+If you are the primary contact on the account and you forget the code or
+need to reset your login, contact your account manager or Rackspace
+Technology Support.
+
+# The global navigation menu
+
+Although the Rackspace Technology customer portal is different for
+[Public Cloud](https://www.rackspace.com/cloud/public) and [Private
+Cloud](https://www.rackspace.com/cloud/private) customers, both portals
+include a global navigation menu that allows you to complete common
+tasks easily.
+
+To access the global navigation menu:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+2.  Select from the global navigation dropdown menu items.
+
+![\*\*charges to date\*\*](/_images/global_nav.png)

--- a/docs/manage_billing/access.md
+++ b/docs/manage_billing/access.md
@@ -1,0 +1,10 @@
+---
+title: Access your billing information
+---
+
+To access your Rackspace billing information, log in to the [Rackspace
+Technology Customer Portal](https://login.rackspace.com) and select
+**Billing** from the global navigation menu.
+
+This selection takes you to the **Billing Overview** dashboard, which
+provides information on billing, payments, and usage.

--- a/docs/manage_billing/index.md
+++ b/docs/manage_billing/index.md
@@ -1,0 +1,11 @@
+---
+title: Manage your Rackspace Technology billing
+---
+
+This chapter provides an introduction to managing your Rackspace
+Technology billing.
+
+::: {.toctree maxdepth="1"}
+access.rst threshold.rst manage_methods.rst update_billing.rst vat.rst
+sla_credit.rst
+:::

--- a/docs/manage_billing/manage_methods.md
+++ b/docs/manage_billing/manage_methods.md
@@ -1,0 +1,35 @@
+---
+title: Manage payment methods
+---
+
+You can view and manage your current payment methods from the
+**Billing** drop-down menu.
+
+# Add a payment method
+
+To add a payment method:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+2.  Select **Billing \> Payment Methods**.
+3.  Select **Add Payment Method**.
+4.  Select the payment method you want to use. The options are **Credit
+    Card** and **ACH (eCheck)**.
+5.  Enter payment method details.
+6.  Select **Save Credit Card** if you entered a credit card, or **Add
+    Account** if you entered a bank account.
+
+# Delete a payment method
+
+To delete a payment method:
+
+1.  Select the gear icon next to the payment method.
+2.  Select **Delete Payment Method**.
+
+# Change the default payment method
+
+To change the default payment method:
+
+1.  Select the gear icon next to the method you want to make the
+    default.
+2.  Select **Set as Default**.

--- a/docs/manage_billing/sla_credit.md
+++ b/docs/manage_billing/sla_credit.md
@@ -1,0 +1,59 @@
+---
+title: Request an SLA credit
+---
+
+Every Rackspace Technology product is backed by an industry-leading
+service level agreement (SLA). You can read this agreement at
+<https://www.rackspace.com/information/legal/cloud/sla>. Use the
+following steps if you experience any issue for which you want to
+receive an SLA credit.
+
+# Prerequisites
+
+To receive a credit, the SLA incident must meet the following criteria:
+
+> -   The SLA incident must have occurred within the previous 30 days.
+> -   For specific concerns not mentioned in the SLA, the issue must
+>     have occurred within the previous 60 days.
+> -   Account balances must be current.
+> -   You must meet SLA requirements and obligations within the
+>     agreed-upon Terms of Service.
+
+# Requesting an SLA credit
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com) .
+
+#\. Create a support ticket and enter **Credit Request** in the
+**Subject** field.
+
+1.  Provide the following information in the support ticket:
+
+    > -   Services affected
+    > -   Summary of the incident
+    > -   Date and time that the issue began
+    > -   Date and time that the issue ended
+    > -   Any associated correspondence relevant to the issue for which
+    >     you want to receive credit such as logs, another ticket
+    >     number, emails, or chats
+    > -   Add any other pertinent details to credit consideration
+
+2.  Select **Submit Ticket**.
+
+Allow three to five business days for Rackspace Technology to receive
+and review your credit request and update your support ticket.
+
+# Issues not addressed by the SLA
+
+If you experience technical issues not specifically addressed by your
+product SLA, Rackspace Technology will still review your issue. You can
+submit a ticket stating your case and why you believe you should get a
+credit. Be sure to state how long you were affected and how you believe
+Rackspace Technology was responsible.
+
+Rackspace Technology does not issue a credit for cases in which the
+Rackspace **Terms of Service** or **Acceptable Use Policy** are
+violated.
+
+If you have any questions, contact the Rackspace Technology Support team
+at 1-800-961-4454 (US toll-free).

--- a/docs/manage_billing/threshold.md
+++ b/docs/manage_billing/threshold.md
@@ -1,0 +1,17 @@
+---
+title: Set a billing threshold
+---
+
+The **Set Billing Threshold** option enables you to receive a
+notification when usage meets or exceeds an amount that you specify.
+When this occurs, Rackspace emails the primary contact and the billing
+contact.
+
+To enable this functionality, use the following steps:
+
+1.  Select **Set Billing Threshold** from the **Charges to Date**
+    section. The **Billing Settings** page displays.
+2.  Click the pencil icon next to **Threshold Notification**.
+3.  Enter a monetary amount.
+4.  Check the boxes next to the contacts who should receive the
+    notifications and then select **Save**.

--- a/docs/manage_billing/update_billing.md
+++ b/docs/manage_billing/update_billing.md
@@ -1,0 +1,12 @@
+---
+title: Update your billing information
+---
+
+To modify basic billing information for your account, use the following
+steps:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com)
+2.  Select **Billing Settings**. The **Billing Settings** page displays.
+3.  Click the pencil icon next to the section you want to edit.
+4.  Make your changes and click **Save**.

--- a/docs/manage_billing/vat.md
+++ b/docs/manage_billing/vat.md
@@ -1,0 +1,13 @@
+---
+title: Reclaim VAT
+---
+
+If you\'re a VAT-registered business or organization, in most cases, you
+can reclaim the value-added tax (VAT) that you pay when you buy goods
+and services for your business. To reclaim this money, you must have
+records to support your claim. If you provide Rackspace Technology with
+your VAT ID number, Rackspace can prepare an appropriate invoice for
+your records.
+
+If you\'re not a VAT-registered business or organization, you can\'t
+reclaim the VAT that you pay when you buy goods and services.

--- a/docs/manage_portal_user_groups/api_key.md
+++ b/docs/manage_portal_user_groups/api_key.md
@@ -1,0 +1,47 @@
+---
+title: Manage your API key
+---
+
+You can manage your Rackspace Technology assets with an Application
+Programmer Interface (API). Review [the catalog of Rackspace Technology
+APIs](https://docs.rackspace.com/docs/) for more information.
+
+To begin using Rackspace APIs, you need your API key. Your API key is a
+unique alphanumeric identifier associated with your account. You can use
+it for universal authentication commands for all of your services.
+
+# View your API key
+
+Follow these steps to view your API key:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+2.  Click your username and select **My Profile and Settings** from the
+    global navigation menu.
+3.  Scroll to the **Security Settings** section.
+4.  Select **Show** next to the **Rackspace API Key**.
+
+# Reset your API
+
+Follow these steps to reset your API key:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+2.  Click your username and select **My Profile and Settings** from the
+    global navigation menu.
+3.  Scroll to the **Security Settings** section.
+4.  Select **Reset** next to the **Rackspace API Key**.
+5.  From the confirmation window, select **Generate New Key**. Your new
+    API key displays.
+
+::: note
+::: title
+Note
+:::
+
+When you reset your API key, any third-party applications are
+disconnected until you set the new API key in your application. If you
+are using your API key as a part of server code with a site or
+application, the site or application also breaks. Update your API key
+for any application to which you connected with the previous API key.
+:::

--- a/docs/manage_portal_user_groups/api_key_other.md
+++ b/docs/manage_portal_user_groups/api_key_other.md
@@ -1,0 +1,42 @@
+---
+title: Manage API keys for other users
+---
+
+If you are an administrative user, you might have permissions to manage
+API keys for the entire account.
+
+# View an API key
+
+Use the following steps to view API key for all users on your account:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+2.  Select **Account \> User Management** from the global navigation
+    menu.
+3.  Select a username to display its credentials.
+4.  Select **Show** next to the **Rackspace API Key** .
+
+# Reset the API
+
+Use the following steps to reset the API key for a user on your account:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+2.  Select **Account \> User Management** from the global navigation
+    menu.
+3.  Select a username to display its credentials.
+4.  Select **Reset** next to the **Rackspace API Key** .
+5.  From the confirmation window, select **Generate New Key**. Your new
+    API key displays.
+
+::: note
+::: title
+Note
+:::
+
+When you reset an API key, any third-party applications are disconnected
+until you set the new API key in the application. If the API key is part
+of server code with a site or application, the site or application also
+breaks. Update the API key for any application that was connected with
+the previous API key.
+:::

--- a/docs/manage_portal_user_groups/cloud_groups.md
+++ b/docs/manage_portal_user_groups/cloud_groups.md
@@ -1,0 +1,58 @@
+---
+title: Manage public cloud users and user groups
+---
+
+# Create a new user
+
+Use the following steps to create a new user:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+2.  Select **Account \> User Management** from the global navigation
+    menu.
+3.  Select **Create New User**.
+4.  Enter the new user information.
+5.  Select **Create New User**.
+
+If you are a Rackspace Technology Public Cloud customer, you can also
+leverage user groups to manage your users and permissions. By grouping
+users together and assigning permissions to the group, you can adjust
+access for all users in the group at once, rather than adding or
+revoking access permission for each user individually.
+
+::: note
+::: title
+Note
+:::
+
+Private cloud accounts do not have user groups.
+:::
+
+# Create a user group
+
+Follow these steps to create a user group:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+2.  Select **Account \> User Management** from the global navigation
+    menu.
+3.  Select the **User Group** tab.
+4.  Select **Create New User Group**.
+5.  Enter a Group Name and a longer description for Group Description.
+6.  Select **Create Group**.
+
+# Add and remove group members
+
+To remove a user from a group, clear the checkbox next to their name.
+
+To add a new member or edit an existing member, select **Add/Edit
+Members** and make your changes.
+
+::: note
+::: title
+Note
+:::
+
+If you add a user to a group that has greater permissions than they
+originally had, the lesser permissions are disabled.
+:::

--- a/docs/manage_portal_user_groups/index.md
+++ b/docs/manage_portal_user_groups/index.md
@@ -1,0 +1,11 @@
+---
+title: Manage portal users and groups
+---
+
+The following sections include important information about managing
+Rackspace Technology users and groups.
+
+::: {.toctree maxdepth="1"}
+rbac.rst cloud_groups.rst private_cloud_users.rst api_key.rst
+api_key_other.rst
+:::

--- a/docs/manage_portal_user_groups/private_cloud_users.md
+++ b/docs/manage_portal_user_groups/private_cloud_users.md
@@ -1,0 +1,62 @@
+---
+title: Manage private cloud users
+---
+
+If you are a Rackspace Technology Private Cloud customer with the
+appropriate level of access, you can use the **Account Management**
+drop-down menu from the global navigation menu to manage your users.
+
+Select **Account Management** \> **User Management** to perform the
+following tasks.
+
+-   Create a new user
+-   Export a list of active users as a CSV file
+-   Deactivate a user
+
+# Create a new user
+
+Use the following steps to create a new user:
+
+1.  Log in to the [Rackspace Technology customer
+    portal](https://login.rackspace.com).
+2.  Select **Account \> User Management** from the global navigation
+    menu.
+3.  Select **Create New User**.
+4.  Enter the new user information.
+5.  Select **Create New User**.
+
+# Export a list of active users
+
+Use the following steps to export a list of active users:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+2.  Select **Account \> User Management** from the global navigation
+    menu.
+3.  Select **Export Active User List**. This action downloads a CSV file
+    of all active users.
+
+# Deactivate a user
+
+Use the following steps to deactivate a user:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com).
+2.  Select **Account \> User Management** from the global navigation
+    menu.
+3.  Select the checkbox next to the name of the user that you would like
+    to delete.
+4.  Select **Deactivate selected users**.
+
+::: note
+::: title
+Note
+:::
+
+Deactivating a user only removes their access to MyRackspace. Access to
+any devices under your account are not affected. The deactivated user
+still receives ticket update emails and can call Rackspace for support.
+If you need to delete a user on your account entirely, you can do so
+from the user\'s details page. A deleted user cannot call Rackspace for
+support or get any information about your account.
+:::

--- a/docs/manage_portal_user_groups/rbac.md
+++ b/docs/manage_portal_user_groups/rbac.md
@@ -1,0 +1,15 @@
+---
+title: Role-based access control
+---
+
+Role-Based Access Control (RBAC) is a secure method of restricting
+account access to authorized users. This method enables account owners
+to add users and assign roles. Each role has specific permissions
+defined by Rackspace Technology. RBAC enables users to perform actions
+based on the scope of their assigned roles.
+
+Account owners can create up to 100 users, each with their own password
+and API key.
+
+To learn more about RBAC, visit [the support
+site](https://support.rackspace.com/how-to/getting-started-with-role-based-access-control-rbac/).

--- a/docs/notifications/index.md
+++ b/docs/notifications/index.md
@@ -1,0 +1,33 @@
+---
+title: Manage your notifications
+---
+
+Select the **Notifications** drop-down menu from the global navigation
+menu to view important updates related to your account.
+
+![\*\*notifications page\*\*](/_images/notifications_main.png)
+
+You can perform the following actions from the **Notifications** page:
+
+  ------------ ---------------------
+  1            Edit notification
+               preferences
+
+  2            Search and view
+               notifications
+
+  3            Perform additional
+               actions related to
+               this notification
+
+  4            Reply to a
+               notification by
+               creating a ticket
+  ------------ ---------------------
+
+The following sections contain information about:
+
+::: {.toctree maxdepth="1"}
+managing_notifications.rst notification_preferences.rst
+user_preferences.rst situation_tickets.rst interpret_situation.rst
+:::

--- a/docs/notifications/interpret_situation.md
+++ b/docs/notifications/interpret_situation.md
@@ -1,0 +1,172 @@
+---
+title: Interpret a situation ticket
+---
+
+The following section explains how to interpret the three parts of a
+situation ticket:
+
+-   Subject line
+-   Initial and additional comments
+-   Ticket summary
+
+# Subject line
+
+When a situation ticket is generated or AIOps adds alerts to the
+situation, the subject line dynamically updates to reflect the most
+recent information. The following image shows the subject line of a
+situation ticket:
+
+> ![\*\*subject line for situation tickets\*\*](/_images/situation_subject.png)
+
+The following table describes the parts of a situation ticket subject
+line:
+
+  -----------------------------------------------------------------------
+  Section                             Description
+  ----------------------------------- -----------------------------------
+  Situation number                    A unique situation number.
+
+  Alert description                   The number of alerts associated
+                                      with the situation ticket.
+
+  Alert count                         The number of alerts associated
+                                      with the situation ticket.
+
+  Ticket number                       A unique ticket number.
+  -----------------------------------------------------------------------
+
+# Initial and additional comments
+
+Situation tickets update when AIOps adds an alert to the situation. Each
+update includes the new alert, a link to the situation, and the
+Rackspace Notification System (RNS). The following image shows an
+updated sample situation ticket:
+
+> ![\*\*situation tickets additional comments\*\*](/_images/additional_comments.png)
+
+The following table explains how to interpret a situation ticket.
+
+  -----------------------------------------------------------------------
+  Section                             Description
+  ----------------------------------- -----------------------------------
+  A                                   Notifications Link: Shows the link
+                                      to the notifications. Click the
+                                      link to view the associated alerts
+                                      on the **Notifications** page of
+                                      the Rackspace Technology Customer
+                                      Portal. **Important**: You do not
+                                      see notifications for devices for
+                                      which you do not have permissions.
+                                      If you do not see any related
+                                      notifications, review your device
+                                      permissions. After you adjust the
+                                      permissions, you will see alerts
+                                      generated from that point forward.
+
+  B                                   Situation Details: Shows the unique
+                                      situation number, the Account
+                                      Number associated with the
+                                      situation, and the date and time
+                                      the system generated the situation
+                                      ticket.
+
+  C                                   Clustered Alerts: Lists the alerts
+                                      associated with the situation
+                                      ticket.
+  -----------------------------------------------------------------------
+
+# Ticket summary
+
+When the support team clears a situation, the system updates the
+situation ticket with summary information.
+
+::: note
+::: title
+Note
+:::
+
+The summary includes all alerts associated with the ticket, including
+any alerts that you did not previously receive because they were
+initially internal to Rackspace Technology.
+:::
+
+![\*\*situation tickets additional comments\*\*](/_images/ticket_summary.png)
+
+Refer to the following table to understand how to interpret a situation
+ticket summary:
+
+  -----------------------------------------------------------------------
+  Section                             Description
+  ----------------------------------- -----------------------------------
+  A                                   Situation Cleared: Identifies a
+                                      resolved situation as
+                                      [cleared]{.title-ref}.
+
+  B                                   Clustered Alerts: Lists the alerts
+                                      associated with the situation
+                                      ticket that have also been cleared.
+  -----------------------------------------------------------------------
+
+# Navigate to alerts in RNS
+
+The Rackspace Notification System (RNS) contains all alerts associated
+with a situation ticket. From within the ticket, you can navigate to the
+**Notifications** page in the Rackspace Technology Customer Portal.
+
+To navigate to the **Notifications** page, click the link in the ticket.
+
+> ![\*\*situation tickets additional comments\*\*](/_images/rns.png)
+
+RNS filters the **Notifications** page to include only the notifications
+associated with the selected situation ticket. On the **Notifications**
+page, you can perform the following actions:
+
+-   Use the left panel to select the alert you want to view.
+
+-   Use the right panel to see the alert message, view its details, and
+    see the associated device.
+
+-   Click **Actions** to reply to the ticket or modify preferences so
+    that you do not receive notification emails for each alert posted to
+    the **Notifications** page.
+
+    ![\*\*situation tickets additional comments\*\*](/_images/rns2.png)
+
+# Notification emails
+
+By default, the notification system sends you an email for each alert
+associated with a situation ticket. This default setting means that you
+receive an email for each situation ticket and all associated alerts. To
+receive emails for only the situation ticket, refer to **Configure
+notification email preferences**.
+
+> ![\*\*situation tickets additional comments\*\*](/_images/situation_email.png)
+
+# Configure notification email preferences
+
+By default, you receive an email for a situation ticket and associated
+alert notifications. This setting can produce many emails. For example,
+when a server goes down, you receive a ticket email and separate alert
+notification emails informing you of insufficient memory, unavailable
+Apache® service, and a Secure Shell (SSH) error.
+
+You can modify notification preferences to reduce the number of emails
+you receive. You can turn off email notifications globally for all
+devices or select the devices for which you do not want to receive email
+notifications.
+
+::: note
+::: title
+Note
+:::
+
+When you turn off email notifications, either globally or for specific
+devices, you do not receive any notification emails, including warning
+notifications that are not associated with a situation ticket.
+:::
+
+For example, consider a disk usage scenario where the monitoring system
+generates a warning alert at 75% usage and an error alert at 90% usage.
+In this scenario, RNS displays the 75% warning alert but does not
+generate a ticket. When disk usage exceeds 90%, the monitoring system
+generates a ticket.

--- a/docs/notifications/managing_notifications.md
+++ b/docs/notifications/managing_notifications.md
@@ -1,0 +1,29 @@
+---
+title: Manage account notifications
+---
+
+Use the notifications drop-down menu from the global navigation menu to
+view and edit notifications for all users on your account.
+
+# Filter and view notifications
+
+Select the **Notifications** tab from the global navigation drop-down
+menu to display the **Notifications** page.
+
+> -   To sort by notification type, select the tabs above the
+>     notifications list.
+> -   To search by keyword, use the search bar above the notification
+>     list
+> -   To display additional information, select a notification.
+
+# Reply to a notification by creating a ticket
+
+Use the following steps to create a ticket to reply to your
+notification.
+
+1.  Select a notification from the notification list.
+2.  Click **Reply Via ticket** from the bottom of the page or select the
+    **Actions** dropdown at the top of the page and click **Reply via
+    ticket**.
+3.  Enter a detailed description in the text box and select **Create
+    Ticket**.

--- a/docs/notifications/notification_preferences.md
+++ b/docs/notifications/notification_preferences.md
@@ -1,0 +1,20 @@
+---
+title: My notification preferences
+---
+
+You can make updates to how your account receives standard notifications
+by selecting **My Notification Preferences** from the **user settings**
+drop-down menu.
+
+Current options are within the Rackspace portal or by email.
+
+![\*\*charges to date\*\*](/_images/notificationimage.png)
+
+::: note
+::: title
+Note
+:::
+
+If there is a critical event about which you need to be immediately
+informed, Rackspace might override your user settings.
+:::

--- a/docs/notifications/situation_tickets.md
+++ b/docs/notifications/situation_tickets.md
@@ -1,0 +1,29 @@
+---
+title: Situation tickets
+---
+
+In addition to manual tickets that you and the Rackspace Technology
+support team generated, there are also system-generated tickets, known
+as situation tickets.
+
+Rackspace Technology uses artificial intelligence to help streamline how
+your notifications work. In this process, an AIOps integration maps the
+event properties to the AIOps data fields and identifies the source
+event as an AIOps event. These events are grouped into a single alert
+called a *situation*. This technology collects events as raw data and
+uses machine learning to group them based on similarity into situation
+tickets.
+
+AIOps groups events by using machine learning algorithms, based on their
+similarities.
+
+Alerts can be grouped or clustered in several different ways, including:
+
+-   by arrival time
+-   by the time, text string, or description
+-   by a deterministic logic set up by your administrator
+
+AIOps also correlates with information from other systems. AIOps
+identifies any information that is related to the situation ticket and
+notifies the necessary people. AIOps also identifies and suggests for
+any similar historical tickets.

--- a/docs/notifications/user_preferences.md
+++ b/docs/notifications/user_preferences.md
@@ -1,0 +1,20 @@
+---
+title: Edit user notification preferences
+---
+
+If you are an administrator then you can edit notifications for the
+entire account:
+
+1.  Select the **Notifications** tab.
+2.  Select **Edit Preferences** in the upper-right of the notifications
+    list.
+3.  Select from the **Users**, **Categories**, and **Devices** tabs and
+    use the checkboxes to edit your preferences.
+
+::: note
+::: title
+Note
+:::
+
+You can\'t disable Rackspace portal notifications.
+:::

--- a/docs/portal_profile/index.md
+++ b/docs/portal_profile/index.md
@@ -1,0 +1,77 @@
+---
+title: Manage your portal profile
+---
+
+To view and edit your profile settings and the
+`notifications<notifications>`{.interpreted-text role="ref"} for your
+account, select your username from the global navigation menu.
+
+Select **My Profile & Settings** to view your primary contact
+information, view or edit your security settings, and view your account
+and product permissions.
+
+This display is different for Private cloud and Public cloud customers.
+
+# Private cloud
+
+If you are a [Private Cloud](https://www.rackspace.com/cloud/private)
+customer, the following information displays:
+
++--------------------------+---------------------------+
+| Section                  | Description               |
++==========================+===========================+
+| > Ticket Email           | Update your name and      |
+| > Notifications          | contact information       |
++--------------------------+---------------------------+
+| API Access               | > `a                      |
+|                          | pi_key`{.interpreted-text |
+|                          | > role="ref"} for         |
+|                          | > authenticating          |
+|                          | > Rackspace Technology    |
+|                          | > APIs                    |
++--------------------------+---------------------------+
+| User Information         | Update your contact       |
+|                          | information, support PIN, |
+|                          | and password              |
++--------------------------+---------------------------+
+| Support PIN              | A Support PIN is the      |
+|                          | customer secret that the  |
+|                          | customer uses to verify   |
+|                          | their identity when they  |
+|                          | call in for technical,    |
+|                          | billing, or account       |
+|                          | management support        |
++--------------------------+---------------------------+
+| Update Password          | Update your password or   |
+|                          | registration code         |
++--------------------------+---------------------------+
+
+# Public Cloud
+
+If you are a [Public Cloud](https://www.rackspace.com/cloud/public)
+customer, the following information displays:
+
++--------------------------+------------------------------+
+| Section                  | Description                  |
++==========================+==============================+
+| > Primary Contact        | Displays the contact         |
+| > Information            | information for your entire  |
+|                          | Rackspace Cloud solutions    |
+|                          | account. Review              |
+|                          | `change_acc                  |
+|                          | ount_name`{.interpreted-text |
+|                          | role="ref"} for more         |
+|                          | information                  |
++--------------------------+------------------------------+
+| Security Settings        | Change your password, enable |
+|                          | or disable multi-factor      |
+|                          | authentication, and          |
+|                          | `api_key`{.interpreted-text  |
+|                          | role="ref"}                  |
++--------------------------+------------------------------+
+| Rackspace Account        | View your account            |
+| Permissions              | permissions.                 |
++--------------------------+------------------------------+
+| Product Permission       | View the products associated |
+|                          | with your account            |
++--------------------------+------------------------------+

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,17 @@
+---
+title: Contact support
+---
+
+The Support dropdown menu includes the following information:
+
+-   **Support PIN:** Displays information for the primary contact for
+    your Rackspace account and security information such as your
+    password, API key, and support PIN.
+-   **Rackspace System status:** Displays the status of all Rackspace
+    services and related components.
+-   **Support documentation:** Provides links to the Rackspace support
+    documentation site.
+
+Private cloud customers can also view profiles for their Technical
+Support Team members, including their contact information and areas of
+expertise.

--- a/docs/tickets/index.md
+++ b/docs/tickets/index.md
@@ -1,0 +1,22 @@
+---
+title: Manage support tickets
+---
+
+Support tickets enable you to send and receive important information
+about your Rackspace Technology account. Use tickets to communicate with
+Rackspace Technology support and view important system messages.
+
+The **Tickets** drop-down menu enables you to create and manage your
+support tickets. You can use the **Tickets** drop-down menu to perform
+the following actions:
+
+-   **Create tickets:** Create a new support ticket manually or using an
+    existing template.
+-   **Ticket list:** Filter, search, create, and export a list of all
+    your support tickets .
+
+The following sections contain information about:
+
+::: {.toctree maxdepth="1"}
+ticket_private.rst ticket_cloud_panel.rst
+:::

--- a/docs/tickets/ticket_cloud_list.md
+++ b/docs/tickets/ticket_cloud_list.md
@@ -1,0 +1,56 @@
+---
+title: "Rackspace Technology: Ticket list"
+---
+
+The ticket list enables you to create new support tickets and review
+previously opened or closed support tickets.
+
+From the global navigation menu, select **TICKETS \> Ticket Lists**.
+
+![\*\*the ticket list\*\*](/_images/ticket-list.png)
+
+The following table includes a description of the different sections of
+the ticket list.
+
+  ------------ ---------------------
+  1            Create a new ticket
+
+  2            Search your ticket
+               list by keyword
+
+  3            filter based on
+               ticket status
+
+  4            Filter based on
+               ticket type, date,
+               and favorites
+
+  5            Select a ticket from
+               the ticket list to
+               view more
+               information,
+               including any
+               comments that have
+               been made on the
+               ticket.
+
+  6            Select the
+               star-shaped icon to
+               mark a ticket as
+               favorite
+
+  7            Select the checkbox
+               next to one or more
+               tickets to close them
+               directly from the
+               ticket list without
+               viewing the
+               individual tickets.
+
+  8            Select **Update
+               ticket** to make
+               additional public
+               comments to the
+               ticket or upload
+               additional files.
+  ------------ ---------------------

--- a/docs/tickets/ticket_cloud_panel.md
+++ b/docs/tickets/ticket_cloud_panel.md
@@ -1,0 +1,30 @@
+---
+title: "Rackspace Technology customers: Create support tickets"
+---
+
+The following sections explain how Rackspace Technology customers can
+create and view support tickets.
+
+# Create a support ticket
+
+Complete the following steps to create a support ticket:
+
+1.  Log in to [the Rackspace Technology Customer
+    Portal](https://login.rackspace.com)
+2.  Select **TICKETS \> Create Ticket**.
+3.  Select a **Category** for your request.
+4.  Click **Continue**.
+5.  Click **Select Product** \> **Account** \> **Severity** (optional).
+6.  Click **Continue**.
+7.  Enter the specific details of your support request. You can also
+    attach additional files, if necessary.
+8.  Select *Add Recipient*\* if you would like to notify other members
+    of your organization of this support ticket.
+9.  Click **Submit** to finish or **Back** to make more changes.
+
+The following section provides more information about how tickets work
+for public cloud customers:
+
+::: {.toctree maxdepth="1"}
+ticket_cloud_list.rst
+:::

--- a/docs/tickets/ticket_private.md
+++ b/docs/tickets/ticket_private.md
@@ -1,0 +1,43 @@
+---
+title: "Rackspace Technology Dedicated customers: Create support
+  tickets"
+---
+
+The ticketing experience might be different for Rackspace Technology
+Dedicated customers. Rackspace Technology Dedicated customers are those
+with managed hosting for physical and virtual devices.
+
+The following sections explain how Rackspace Technology Dedicated
+customers can create and view support tickets.
+
+Complete the following steps to create a support ticket:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com)
+
+2.  Select **TICKETS \> Create Ticket**.
+
+3.  Select a suggested template from the **subject** drop-down menu or
+    select **Create Custom Ticket**.
+
+    > ![\*\*create a ticket dropdown\*\*](/_images/create_dedicated_ticket.png)
+
+4.  Complete the displayed fields.
+
+    > ![\*\*create a ticket dropdown\*\*](/_images/dedicated_ticket_2.png)
+
+5.  Select **Create Ticket**.
+
+# The ticket list
+
+The ticket list allows you to create new support tickets and review
+previously opened or closed support tickets.
+
+> ![\*\*create a ticket dropdown\*\*](/_images/private_cloud_list.png)
+
+The following sections provides more information about how tickets work
+for private cloud customers:
+
+::: {.toctree maxdepth="1"}
+ticket_private_list.rst ticket_templates.rst
+:::

--- a/docs/tickets/ticket_private_list.md
+++ b/docs/tickets/ticket_private_list.md
@@ -1,0 +1,18 @@
+---
+title: "Rackspace Technology Dedicated customers: ticket list"
+---
+
+The ticket list enables you to create new support tickets and review
+previously opened or closed support tickets.
+
+The following sections provides details about the **Ticket List** page
+for Rackspace Technology Private Cloud customers.
+
+Complete the following steps to access the ticket list:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com)
+
+2.  Select **TICKETS \> Ticket list**.
+
+    > ![\*\*create a ticket dropdown\*\*](/_images/private_cloud_list.png)

--- a/docs/tickets/ticket_templates.md
+++ b/docs/tickets/ticket_templates.md
@@ -1,0 +1,29 @@
+---
+title: Ticket templates
+---
+
+Rackspace Technology Private Cloud customers can use templates to create
+tickets for common issues quickly. Ticket templates help you reduce
+costs by enabling automations for frequent ticket requests. They make it
+easy for you to establish a repeatable and scalable process.
+
+Ticket templates also help Rackspace Technology Support respond to your
+requests quickly.
+
+The following links provide more information about using ticket
+templates:
+
+-   [Create New User on Active domain
+    directory](https://docs.rackspace.com/support/how-to/add-cpu-to-server-or-hypervisor/)
+-   [Add CPU to Server or
+    Hypervisor](https://docs.rackspace.com/support/how-to/add-cpu-to-server-or-hypervisor/)
+-   [Add RAM to Server or
+    Hypervisor](https://docs.rackspace.com/support/how-to/add-ram-to-server-or-hypervisor/)
+-   [Add Disk Space to Server or
+    Hypervisor](https://docs.rackspace.com/support/how-to/add-disk-space-to-server-or-hypervisor/)
+-   [Local User
+    Management](https://docs.rackspace.com/support/how-to/manage-local-users-in-the-myrackspace-portal)
+-   [Reset User Password on Active Directory
+    Domain](https://docs.rackspace.com/support/how-to/reset-user-password-on-active-directory-domain/)
+-   [Generate Certificate Signing Request
+    (CSR)](https://docs.rackspace.com/support/how-to/generate-a-csr/)

--- a/docs/understand_billing/about.md
+++ b/docs/understand_billing/about.md
@@ -1,0 +1,30 @@
+---
+title: About Rackspace Technology billing
+---
+
+As a Rackspace Technology customer, you pay for only the services that
+you use with one exception. Your cloud servers and load balancers are
+billed for uptime as long as they remain in the active status, even if
+they are not being used. These resources are allocated for your
+exclusive use and cannot be reserved by other customers.
+
+Finally, Rackspace charges for only outbound bandwidth, meaning that
+routine site maintenance, such as content publishing and uploads, does
+not affect your bandwidth allocation.
+
+Your 30-day billing cycle begins on the day that you activate your
+account, and your bill reflects services used in the previous month. If
+your usage begins in the middle of a billing cycle, your first bill
+reflects a partial month.
+
+The **Billing** section displays the following information:
+
+-   **Billing Overview**: Snapshot of balance, charges, transactions,
+    and month-to-month trends.
+-   **Invoice Details**: Detailed printable view of your monthly
+    invoices.
+-   **Charges to date**: Overview of all charges to date.
+-   **Payment Methods**: View and edit payment methods.
+-   **Make Payment**: Submit a payment.
+-   **Billing Settings**: Update your contact and invoice delivery
+    information.

--- a/docs/understand_billing/account_invoice.md
+++ b/docs/understand_billing/account_invoice.md
@@ -1,0 +1,119 @@
+---
+title: Your Rackspace Technology account invoice
+---
+
+Your monthly Rackspace account invoice includes account and billing
+information, payment information, tax information, and summaries of your
+services, promotions, and discounts. This section provides a detailed
+description of the pages in your PDF or CSV invoice.
+
+# Account and billing information
+
+The first page of your PDF invoice provides a detailed overview of your
+account and billing information.
+
+## Account summary
+
+The bottom portion of the first page of your invoice includes the
+following information:
+
+> -   **Invoice Number:** The transaction number associated with the
+>     invoice.
+> -   **Invoice Date:** The date the invoice was generated.
+> -   **Currency:** The monetary currency in which your account is
+>     invoiced.
+> -   **Invoice Amount Due:** The total amount due for your current
+>     invoice charges. This amount does not include any past due
+>     balance.
+> -   **Payment Terms:** The time range within which payment should be
+>     received, in days.
+> -   **Due Date:** The date that the payment is due.
+> -   **Remit Section (if applicable):** The section to detach and send
+>     with your payment.
+
+## Service summary
+
+The second page of your invoice summarizes all support charges, product
+charges, and other charges. This page has the following information:
+
+> -   **Service:** The support, product, or other charges applied to
+>     your current bill.
+> -   **Gross Charge:** The total charge before promotions and
+>     discounts.
+> -   **Promotion & Discount:** The promotions and discounts associated
+>     with a product charge.
+> -   **Net Charge:** The pretax amount for a product charge. This
+>     amount is the difference between the Gross Charge and the
+>     Promotion & Discount for a product charge.
+> -   **Taxes:** The tax amount applied. Taxes are calculated based on
+>     the Net Charge.
+> -   **Total Charges:** The sum of the Net Charge and the taxes for a
+>     product.
+
+While most of the service summary items are self-explanatory, two
+services warrant additional description:
+
+> -   **Cloud Servers:** This field includes all of the Cloud Server
+>     flavor classes, such as OnMetal.
+> -   **Cloud Bandwidth:** This field includes both Public and CDN
+>     Bandwidth.
+
+## Other services
+
+The third page of your invoice includes other charges accrued during the
+billing period.
+
+> -   **Service:** The support, product, or other charges applied to
+>     your current bill, including a descriptive name for the product or
+>     charge.
+> -   **Gross Charge:** The total charge before promotions and
+>     discounts.
+> -   **Promotion & Discount:** The promotions and discounts associated
+>     with a product charge.
+> -   **Net Charge:** The pretax amount for a product charge. This
+>     amount is the difference between the Gross Charge and the
+>     Promotion & Discount for a product charge.
+> -   **Taxes:** The tax amount applied. Taxes are calculated based on
+>     the Net Charge.
+> -   **Total Charges:** The sum of the Net Charge and the Taxes for a
+>     product.
+> -   **Total Current Invoice Charges:** The total for all of the
+>     accumulative charges applied to the invoice.
+
+## Promotion and discount summary
+
+The fourth page of your invoice provides a summary of the promotions and
+discounts for the billing period.
+
+> -   **Category and Description:** The names and descriptions of the
+>     promotions and discounts applied to your bill.
+> -   **Net Discount:** The total amount that is deducted from your bill
+>     due to promotions and discounts.
+
+## Tax summary
+
+The fifth page of your invoice contains a **Tax Summary** section that
+explains the taxes applied to your bill in detail.
+
+If you are assessed a Goods and Services Tax (GST), you also see the
+aggregate product charges. These charges break down into taxable (T) and
+non-taxable charges for the billing period.
+
+## Invoice details document (CSV)
+
+Invoice detail documents in CSV format provide detailed information on
+daily usage for the billing cycle. Each row contains a daily usage item
+and an associated charge. You can also view summaries of charges across
+the entire billing cycle in the following three views:
+
+> -   **Resource:** To view a summary for a specific resource, create a
+>     PivotTable on the **RES_ID** column.
+>
+> -   **Service:** To view a summary for a specific service, create a
+>     PivotTable on the **SERVICE_TYPE** column.
+>
+> -   
+>
+>     **Data center:** To view a specific data center summary,
+>
+>     :   create a PivotTable on the **DC_ID** column.

--- a/docs/understand_billing/current_usage.md
+++ b/docs/understand_billing/current_usage.md
@@ -1,0 +1,30 @@
+---
+title: View your current usage
+---
+
+The center panel of the **Billing Dashboard** displays your **Charges to
+Date**. Perform the following steps, as needed:
+
+-   To see a detailed breakdown of the charges, select **View** from the
+    section header.
+
+    > The balance-to-date for the Rackspace Technology products that you
+    > are using appears.
+
+-   To see the usage details such as type, unit price, quantity, and
+    estimated total, select the carat (\^) to the right of the dollar
+    amount.
+
+::: note
+::: title
+Note
+:::
+
+This page displays only the usage that you accrued after your last
+invoice was generated. Usage information accrues throughout the month,
+and totals update on a daily basis. Some products and services might
+take up to 24 hours to appear on this page. Additionally, some charge
+totals only appear after any discounts have been applied.
+:::
+
+![\*\*charges to date\*\*](/_images/chargestodate.png)

--- a/docs/understand_billing/detailed_permissions.md
+++ b/docs/understand_billing/detailed_permissions.md
@@ -1,0 +1,114 @@
+---
+title: Permissions for billing and payment services
+---
+
+Review the following permissions matrix to understand the specific
+billing and payment services capabilities for the following roles:
+
+> -   **Admin**: Provides full access to create, read, update, and
+>     delete.
+> -   **Observer**: Provides read-only access.
+
+# Billing services
+
+  -----------------------------------------------------------------------
+  Capability            Role                     Description
+  --------------------- ------------------------ ------------------------
+  List account balance  Observer, Admin          Returns the balance for
+                                                 the current account
+
+  List billing summary  Observer, Admin          Returns the billing
+                                                 summary for the current
+                                                 account.
+
+  List account currency Observer, Admin          Returns the currency for
+                                                 the current account
+
+  List account billing  Observer, Admin          Returns the invoice for
+  cycle                                          the current account, in
+                                                 PDF format.
+
+  List current invoice  Observer, Admin          Returns the billing
+                                                 summary for the current
+                                                 account.
+
+  List invoice by ID    Observer, Admin          Returns a specific
+                                                 invoice, in PDF format.
+
+  List invoice payments Observer, Admin          Returns a list of
+                                                 payments related to an
+                                                 invoice.
+
+  List account payment  Observer, Admin          Lists a specific payment
+                                                 by ID.
+
+  List refund by ID     Observer, Admin          Lists a specific refund.
+
+  List billing periods  Observer, Admin          Returns a list of
+                                                 billing periods.
+
+  List estimated        Observer, Admin          Returns a list of
+  charges                                        summarized estimated
+                                                 charges for a specific
+                                                 billing period.
+
+  List subscriptions    Observer, Admin          Returns a list of
+                                                 subscriptions for the
+                                                 account.
+
+  List contract entity  Observer, Admin          Retrieves a Rackspace
+                                                 Contract entity for a
+                                                 billing account.
+
+  Create payment        Admin                    Submits a payment for
+                                                 the balance owed by an
+                                                 account.
+
+  Update account VAT    Admin                    Updates the Value Added
+                                                 Tax (VAT) code for the
+                                                 account.
+
+  List account VAT      Observer, Admin          Returns the Value Added
+                                                 Tax (VAT) code for the
+                                                 current account.
+
+  Create account VAT    Admin                    Creates a Value Added
+                                                 Tax (VAT) code for the
+                                                 current account.
+
+  Delete account VAT    Admin                    Deletes the Value Added
+                                                 Tax (VAT) code for a
+                                                 current account.
+  -----------------------------------------------------------------------
+
+# Payment services
+
+  -----------------------------------------------------------------------
+  Capability            Role                     Description
+  --------------------- ------------------------ ------------------------
+  Get payment method    Observer, Admin          Returns the payment
+                                                 method for the current
+                                                 account.
+
+  Get default payment   Observer, Admin          Returns the default
+                                                 payment method for the
+                                                 current account.
+
+  Create payment method Admin                    Creates a payment method
+                                                 for the current account.
+
+  Set default payment   Admin                    Deletes the default
+                                                 payment method for the
+                                                 current account.
+  -----------------------------------------------------------------------
+
+::: note
+::: title
+Note
+:::
+
+Role-Based Access Control (RBAC) is enabled for the billing-services
+level (BSL) and payment-services level (PSL) only through the [Rackspace
+Technology Customer Portal](https://login.rackspace.com). Rackspace
+Technology does not provide API access for BSL and PSL at this time.
+:::

--- a/docs/understand_billing/estimate.md
+++ b/docs/understand_billing/estimate.md
@@ -1,0 +1,9 @@
+---
+title: Estimate your monthly charges
+---
+
+Each product page on the [Rackspace Technology
+website](https://www.rackspace.com/) includes the pricing for that
+product and a cost calculator to help you estimate your monthly charges.
+For an example, see the [pricing information for Cloud
+Servers](https://www.rackspace.com/cloud/servers/pricing).

--- a/docs/understand_billing/help.md
+++ b/docs/understand_billing/help.md
@@ -1,0 +1,11 @@
+---
+title: Get help with Rackspace Technology billing
+---
+
+If you\'re unable to find the information that you need in the
+[Rackspace Technology Portal](https://login.rackspace.com) or if you
+need more detailed billing and payment information, contact the Billing
+Support team. This team is available Monday through Friday from 8 a.m.
+to 5 p.m. CST, toll-free at 877 934 0410 or internationally at 1 210 581
+0410. You can reach the Cloud Accounts Receivable team toll-free at 800
+480 2716 or internationally at 1 210 312 4000.

--- a/docs/understand_billing/index.md
+++ b/docs/understand_billing/index.md
@@ -1,0 +1,11 @@
+---
+title: Understand your Rackspace Technology billing
+---
+
+This chapter provides an introduction to understanding your Rackspace
+Technology billing.
+
+::: {.toctree maxdepth="1"}
+about.rst estimate.rst current_usage.rst invoice_details.rst
+account_invoice.rst detailed_permissions.rst help.rst
+:::

--- a/docs/understand_billing/invoice_details.md
+++ b/docs/understand_billing/invoice_details.md
@@ -1,0 +1,32 @@
+---
+title: View invoice details
+---
+
+To access detailed information about your invoices:
+
+1.  Log in to the [Rackspace Technology Customer
+    Portal](https://login.rackspace.com) .
+
+2.  Select **Billing \> Invoice Details**.
+
+    A detailed view of your most recent invoice displays.
+
+    ![\*\*detailed invoice\*\*](/_images/invoice-detailed.png)
+
+    Line items appear under the **Total Charges** section. To expand a
+    line item, select the down arrow to the left of the item
+    description.
+
+    If there are per-device charges associated with a line item, a
+    **Devices** area appears inside that line item. To expand this area
+    further and display the cost associated with each device, select the
+    down arrow to the left of **Devices**.
+
+> ![\*\*device area\*\*](/_images/devices.png)
+
+To download an invoice, select the **PDF** or the **CSV** link at the
+
+:   top-right corner of the page.
+
+To view past invoices, select a date from the **Bill Date** drop-down
+menu.


### PR DESCRIPTION
I wanted to explore automation migration of RST-based docs to Markdown to gauge whether it will be a feasible strategy for migration to ReadMe. I ran the following command to convert all RST files:

```
find . -name \*.rst -exec bash -c 'pandoc $0 -s -o ${0%.rst}.md' {} \;
```
